### PR TITLE
Add support for 'externalbrowser' authentication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     jose,
     openssl
 Suggests:
+    httpuv,
     testthat (>= 3.0.0),
     withr
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   file does not exist are now clearer (#23).
 * Error messages when `connections.toml` exists but lacks a needed connection are
   now more specific and helpful (#26).
+* Add support for `externalbrowser` authentication.
 
 # snowflakeauth 0.2.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -174,6 +174,13 @@ snowflake_connection <- function(
     ))
   }
 
+  # Validate external browser authentication
+  if (params$authenticator == "externalbrowser" && is.null(params$user)) {
+    cli::cli_abort(c(
+      "A {.arg user} parameter is required when using external browser authentication."
+    ))
+  }
+
   # Redact sensitive data
   params$password <- redact(params[["password"]])
   params$token <- redact(params[["token"]])

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -43,9 +43,10 @@ snowflake_credentials <- function(
       spcs_endpoint,
       role
     ),
+    externalbrowser = externalbrowser_credentials(params),
     cli::cli_abort(c(
       "Unsupported authenticator: {.str {params$authenticator}}.",
-      "i" = "Only OAuth and key-pair authentication are supported."
+      "i" = "Supported authenticators: oauth, SNOWFLAKE_JWT, externalbrowser"
     ))
   )
 }
@@ -57,4 +58,138 @@ formEncode <- function(form_data) {
     curl::curl_escape(form_data),
     collapse = "&"
   )
+}
+
+# In-memory cache for Snowflake sessions. Analogous to httr2:::cache_mem().
+session_cache <- function(params) {
+  key <- rlang::hash(params)
+  list(
+    get = function() rlang::env_get(the$session_cache, key, default = NULL),
+    set = function(session) rlang::env_poke(the$session_cache, key, session),
+    clear = function() rlang::env_unbind(the$session_cache, key)
+  )
+}
+
+# Wrap a Snowflake session response into an S3 object.
+snowflake_session <- function(data, .now = Sys.time()) {
+  # The actual token field has different field names depending on the endpoint.
+  token <- data[["token"]] %||% data[["sessionToken"]]
+
+  if (is.null(token)) {
+    cli::cli_abort(
+      "Unexpected response body: missing session token"
+    )
+  }
+
+  expires_at <- as.numeric(.now) + data[["validityInSeconds"]]
+
+  # Don't store expiry for tokens we don't have.
+  master_expires_at <- NULL
+  if (!is.null(data[["masterToken"]])) {
+    master_expires_at <- as.numeric(.now) + data[["masterValidityInSeconds"]]
+  }
+  id_token_expires_at <- NULL
+  if (!is.null(data[["idToken"]])) {
+    id_token_expires_at <- as.numeric(.now) + data[["idTokenValidityInSeconds"]]
+  }
+
+  structure(
+    # Drop NULL fields via Filter.
+    Filter(
+      length,
+      list(
+        id = data[["sessionId"]],
+        token = token,
+        expires_at = expires_at,
+        master_token = data[["masterToken"]],
+        master_expires_at = master_expires_at,
+        id_token = data[["idToken"]],
+        id_token_expires_at = id_token_expires_at,
+        info = data[["sessionInfo"]]
+      )
+    ),
+    class = "snowflake_session"
+  )
+}
+
+# Check if a token timestamp will expire "in the next five minutes".
+has_expired <- function(expires_at, .now = Sys.time()) {
+  is.null(expires_at) || (as.integer(.now) + 5L) > expires_at
+}
+
+# Generic helper for calls to the /login-request endpoint.
+login_request <- function(account, data, extra_headers = list()) {
+  url <- sprintf(
+    "https://%s.snowflakecomputing.com/session/v1/login-request",
+    account
+  )
+  body <- jsonlite::toJSON(list(data = data), auto_unbox = TRUE)
+  headers <- c(
+    extra_headers,
+    `Content-Type` = "application/json",
+    `Accept` = "application/json"
+  )
+
+  handle <- curl::new_handle()
+  curl::handle_setopt(handle, postfields = body)
+  curl::handle_setheaders(handle, .list = headers)
+
+  resp <- curl::curl_fetch_memory(url, handle)
+  if (resp$status_code >= 400) {
+    cli::cli_abort(c(
+      "Snowflake login request failed",
+      i = "Status code: {.strong {resp$status_code}}"
+    ))
+  }
+
+  content <- jsonlite::fromJSON(rawToChar(resp$content), simplifyVector = FALSE)
+  if (!isTRUE(content$success) || is.null(content$data)) {
+    cli::cli_abort("Received unexpected response during login request")
+  }
+
+  snowflake_session(content$data)
+}
+
+# Renew an existing Snowflake session using its "master" token.
+renew_session <- function(account, session) {
+  url <- sprintf(
+    "https://%s.snowflakecomputing.com/session/token-request",
+    account
+  )
+  body <- jsonlite::toJSON(
+    list(
+      oldSessionToken = session$token,
+      requestType = "RENEW"
+    ),
+    auto_unbox = TRUE
+  )
+
+  handle <- curl::new_handle()
+  curl::handle_setopt(handle, postfields = body)
+  curl::handle_setheaders(
+    handle,
+    `Content-Type` = "application/json",
+    `Accept` = "application/json",
+    `Authorization` = sprintf('Snowflake Token="%s"', session$master_token)
+  )
+
+  resp <- curl::curl_fetch_memory(url, handle)
+  if (resp$status_code >= 400) {
+    cli::cli_abort(c(
+      "Failed to renew session",
+      i = "Status code: {.strong {resp$status_code}}"
+    ))
+  }
+
+  content <- jsonlite::fromJSON(rawToChar(resp$content), simplifyVector = FALSE)
+  if (!isTRUE(content$success) || is.null(content$data)) {
+    cli::cli_abort(
+      "Received unexpected response while renewing session"
+    )
+  }
+
+  renewed <- snowflake_session(content$data)
+  # TODO: This might not be necessary.
+  renewed$id_token <- renewed$id_token %||% session$id_token
+  renewed
 }

--- a/R/externalbrowser.R
+++ b/R/externalbrowser.R
@@ -1,0 +1,228 @@
+# Support for "external browser" SSO authentication, including an in-memory cache.
+externalbrowser_credentials <- function(
+  params,
+  cache = session_cache(params)
+) {
+  account <- params$account
+  user <- params$user
+  if (!interactive()) {
+    cli::cli_abort(c(
+      "External browser authentication requires an interactive R session",
+      "i" = "Use a different authenticator"
+    ))
+  }
+
+  if (is_hosted_session()) {
+    cli::cli_abort(c(
+      "External browser authentication does not work in a hosted environment",
+      "i" = "Use a different authenticator"
+    ))
+  }
+
+  rlang::check_installed(
+    "httpuv",
+    reason = "for external browser authentication"
+  )
+
+  # This is a totally custom protocol that seems to be doubly-influenced by
+  # SAML and OpenID Connect.
+
+  # Check for a cached session before launching the browser flow.
+  cached <- cache$get()
+  if (!is.null(cached)) {
+    if (!has_expired(cached$expires_at)) {
+      return(list(
+        Authorization = sprintf('Snowflake Token="%s"', cached$token)
+      ))
+    }
+
+    # If the session token has expired but the master token is still valid,
+    # attempt to refresh the session.
+    if (!has_expired(cached$master_expires_at)) {
+      tryCatch(
+        {
+          session <- renew_session(account, cached)
+          session$id_token <- session$id_token %||% cached$id_token
+          cache$set(session)
+          return(list(
+            Authorization = sprintf('Snowflake Token="%s"', session$token)
+          ))
+        },
+        error = function(e) {
+          NULL
+        }
+      )
+    }
+
+    # If we have a cached ID token, attempt to get a new session with it.
+    #
+    # This is only possible on Snowflake accounts that have opted into this.
+    if (!has_expired(cached$id_token_expires_at)) {
+      tryCatch(
+        {
+          session <- login_request(
+            account,
+            data = list(
+              AUTHENTICATOR = "ID_TOKEN",
+              TOKEN = cached$id_token
+            )
+          )
+          cache$set(session)
+          return(list(
+            Authorization = sprintf('Snowflake Token="%s"', session$token)
+          ))
+        },
+        error = function(e) {
+          # Clear the now-invalid cache.
+          cache$clear()
+          NULL
+        }
+      )
+    }
+  }
+
+  # Request the user's SSO URL and "proof key" from Snowflake.
+  port <- httpuv::randomPort()
+  result <- request_sso_url(account, user, port)
+  sso_url <- result$sso_url
+  proof_key <- result$proof_key
+
+  # Open the SSO URL and listen for the redirect.
+  utils::browseURL(sso_url)
+  token <- localhost_listen(port)
+
+  # Exchange the identity token and proof key for an authentication token.
+  session <- login_request(
+    account,
+    data = list(
+      AUTHENTICATOR = "EXTERNALBROWSER",
+      TOKEN = token,
+      PROOF_KEY = proof_key
+    )
+  )
+
+  # Cache the session for headless refreshing (when possible).
+  cache$set(session)
+
+  return(list(
+    Authorization = sprintf('Snowflake Token="%s"', session$token)
+  ))
+}
+
+# Try to determine whether we can redirect the user's browser to a server on
+# localhost, which isn't possible if we are running on a hosted platform.
+#
+# Currently this detects RStudio Server, Posit Workbench, and Google Colab. It
+# is based on the strategy pioneered by the {gargle} package.
+is_hosted_session <- function() {
+  if (nzchar(Sys.getenv("COLAB_RELEASE_TAG"))) {
+    return(TRUE)
+  }
+  # If RStudio Server or Posit Workbench is running locally (which is possible,
+  # though unusual), it's not acting as a hosted environment.
+  Sys.getenv("RSTUDIO_PROGRAM_MODE") == "server" &&
+    !grepl("localhost", Sys.getenv("RSTUDIO_HTTP_REFERER"), fixed = TRUE)
+}
+
+request_sso_url <- function(account, user, callback_port) {
+  url <- sprintf(
+    "https://%s.snowflakecomputing.com/session/authenticator-request",
+    account
+  )
+  body <- jsonlite::toJSON(
+    list(
+      data = list(
+        ACCOUNT_NAME = NULL,
+        LOGIN_NAME = user,
+        AUTHENTICATOR = "EXTERNALBROWSER",
+        BROWSER_MODE_REDIRECT_PORT = as.character(callback_port)
+      )
+    ),
+    auto_unbox = TRUE
+  )
+
+  handle <- curl::new_handle()
+  curl::handle_setopt(handle, postfields = body)
+  curl::handle_setheaders(
+    handle,
+    `Content-Type` = "application/json",
+    `Accept` = "application/json"
+  )
+
+  resp <- curl::curl_fetch_memory(url, handle)
+  if (resp$status_code >= 400) {
+    cli::cli_abort(c(
+      "Failed to obtain SSO URL from Snowflake",
+      i = "Status code: {.strong {resp$status_code}}",
+    ))
+  }
+
+  content <- jsonlite::fromJSON(rawToChar(resp$content), simplifyVector = FALSE)
+  if (
+    !isTRUE(content$success) ||
+      is.null(content[["data"]]) ||
+      is.null(content[["data"]][["ssoUrl"]]) ||
+      is.null(content[["data"]][["proofKey"]])
+  ) {
+    cli::cli_abort(
+      "Received unexpected response body while obtaining SSO URL from Snowflake",
+    )
+  }
+
+  list(
+    sso_url = content[["data"]][["ssoUrl"]],
+    proof_key = content[["data"]][["proofKey"]]
+  )
+}
+
+localhost_listen <- function(port) {
+  token <- NULL
+  done <- FALSE
+
+  listen <- function(req) {
+    if (!identical(req$PATH_INFO, "/") || req$REQUEST_METHOD != "GET") {
+      return(list(
+        status = 404L,
+        headers = list("Content-Type" = "text/plain"),
+        body = "Not found"
+      ))
+    }
+
+    if (!is.character(req$QUERY_STRING)) {
+      done <<- TRUE
+      return(list(
+        status = 400L,
+        headers = list("Content-Type" = "text/plain"),
+        body = "Missing token parameter"
+      ))
+    }
+
+    # Note: we might want to actual parse the query string properly here.
+    # But for now, take advantage of the fact that it will only contain
+    # one parameter.
+    token <<- gsub("\\?token=([^&]+)", "\\1", req$QUERY_STRING)
+    done <<- TRUE
+
+    list(
+      status = 200L,
+      headers = list("Content-Type" = "text/plain"),
+      body = "Authentication complete. Please close this page and return to R."
+    )
+  }
+
+  server <- httpuv::startServer("127.0.0.1", port, list(call = listen))
+  on.exit(httpuv::stopServer(server), add = TRUE)
+
+  rlang::inform("Waiting for authentication in browser...")
+  rlang::inform("Press Esc/Ctrl + C to abort")
+  while (!done) {
+    httpuv::service()
+  }
+  httpuv::service()
+
+  if (is.null(token)) {
+    cli::cli_abort("Authentication failed")
+  }
+
+  token
+}

--- a/R/snowflakeauth-package.R
+++ b/R/snowflakeauth-package.R
@@ -1,6 +1,9 @@
 #' @keywords internal
 "_PACKAGE"
 
+the <- rlang::new_environment()
+the$session_cache <- rlang::new_environment()
+
 ## usethis namespace: start
 #' @importFrom rlang is_empty
 #' @importFrom rlang %||%

--- a/README.Rmd
+++ b/README.Rmd
@@ -79,9 +79,8 @@ of a one or more of HTTP headers:
 ```{r credentials, eval = FALSE}
 conn <- snowflake_connection(
   account = "myaccount",
-  user = "me",
-  authenticator = "oauth",
-  token = "token"
+  user = "myuser@company.com",
+  authenticator = "externalbrowser"
 )
 
 snowflake_credentials(conn)
@@ -89,7 +88,8 @@ snowflake_credentials(conn)
 
 ## Limitations
 
-- No support for SSO authentication using a browser.
+- Browser-based authentication is known to fail in Positron, but should work in
+  RStudio.
 
 - No support for [connection
   caching](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#using-connection-caching-to-minimize-the-number-of-prompts-for-authentication-optional).

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ the form of a one or more of HTTP headers:
 ``` r
 conn <- snowflake_connection(
   account = "myaccount",
-  user = "me",
-  authenticator = "oauth",
-  token = "token"
+  user = "myuser@company.com",
+  authenticator = "externalbrowser"
 )
 
 snowflake_credentials(conn)
@@ -79,7 +78,8 @@ snowflake_credentials(conn)
 
 ## Limitations
 
-- No support for SSO authentication using a browser.
+- Browser-based authentication is known to fail in Positron, but should work in
+  RStudio.
 
 - No support for [connection
   caching](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#using-connection-caching-to-minimize-the-number-of-prompts-for-authentication-optional).


### PR DESCRIPTION
This commit adds the machinery to support the "externalbrowser" authenticator, which is an interactive sign-in flow for users with access to a local browser. It includes session caching, which is a nice ergonomic improvement for repeated calls.

(The underlying protocol is completely bespoke to Snowflake so it took me a little while to get it actually working.)

You can test it as follows:

    snowflake_connection(
      account = <account>
      user = <username>,
      authenticator = "externalbrowser"
    ) |> snowflake_credentials()

This should open a browser window to the account's SSO provider.

Unfortunately this is all highly interactive code, so there is not much to unit test.