### PR TITLE
Fix misleading warnings when both configuration files exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # snowflakeauth (development version)
 
+* Misleading warnings about the `config.toml` and `connections.toml` files both
+  existing have been removed (#25).
+
 # snowflakeauth 0.2.0
 
 * `jose` and `openssl` have been upgraded to required dependencies.

--- a/R/config.R
+++ b/R/config.R
@@ -311,10 +311,11 @@ load_config <- function(
     }
     connections <- RcppTOML::parseTOML(connections_toml, fromFile = TRUE)
 
-    # If both files exist, inform user we're using connections.toml
-    if (has_config_toml && length(connections) > 0) {
+    # If both files define connections, inform the user that connections.toml
+    # takes precedence.
+    if (length(result$connections) > 0 && length(connections) > 0) {
       cli::cli_inform(c(
-        "!" = "Both {.file connections.toml} and {.file config.toml} exist. Using {.file connections.toml}."
+        "!" = "Both {.file connections.toml} and {.file config.toml} define connections. {.file connections.toml} takes precedence."
       ))
 
       # Validate that connection name from config.toml exists in connections.toml

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -109,7 +109,6 @@
     Code
       snowflake_connection(.config_dir = config_dir)
     Message
-      ! Both 'connections.toml' and 'config.toml' exist. Using 'connections.toml'.
       <Snowflake connection: secondary>
       account: "secondary-test-account"
       role: "role"
@@ -142,9 +141,20 @@
     Code
       snowflake_connection()
     Message
-      ! Both 'connections.toml' and 'config.toml' exist. Using 'connections.toml'.
       <Snowflake connection: workbench>
       account: "testorg-test_account"
       authenticator: "oauth"
       token: <REDACTED>
+
+# warning appears when both files define connections
+
+    Code
+      snowflake_connection(.config_dir = config_dir)
+    Message
+      ! Both 'connections.toml' and 'config.toml' define connections. 'connections.toml' takes precedence.
+      <Snowflake connection: default>
+      account: "testorg-from-connections"
+      role: "role"
+      user: "user"
+      authenticator: "snowflake"
 


### PR DESCRIPTION
Previously we warned if we detected if both files were present, but this is perfectly valid configuration in many cases. This commit instead focused on warning when both files define connections, which is *not* valid configuration.

Fixes #25.