### PR TITLE
Improve error messages when connections.toml does not exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Misleading warnings about the `config.toml` and `connections.toml` files both
   existing have been removed (#25).
+* Error messages when a named connection is requested but the `connections.toml`
+  file does not exist are now clearer (#23).
 
 # snowflakeauth 0.2.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -92,6 +92,14 @@ snowflake_connection <- function(
 
   # Error if the specified connection doesn't exist
   if (!is.null(connection_name) && is.null(connections[[connection_name]])) {
+    if (!file.exists(connection_file)) {
+      cli::cli_abort(c(
+        "Named connection {.str {connection_name}} refers to a section in
+         {.file {connection_file}}, but that file does not exist.",
+        i = "Create it and define a {.field [{connection_name}]} section, or
+             omit the {.arg name} parameter."
+      ))
+    }
     cli::cli_abort(c(
       "Unknown connection {.str {connection_name}}.",
       i = "Try defining a {.field [{connection_name}]} section in {.file {connection_file}} or
@@ -110,6 +118,7 @@ snowflake_connection <- function(
 
   # Validate that account is provided
   if (is_empty(params$account)) {
+    connection_name <- connection_name %||% "default"
     cli::cli_abort(c(
       "An {.arg account} parameter is required when {.file {connection_file}} is missing or empty.",
       i = "Pass {.arg account} or define a {.field [{connection_name}]} section with an {.field account} field in {.file {connection_file}}."

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -87,7 +87,7 @@
     Condition
       Error in `snowflake_connection()`:
       ! An `account` parameter is required when './connections.toml' is missing or empty.
-      i Pass `account` or define a [] section with an account field in './connections.toml'.
+      i Pass `account` or define a [default] section with an account field in './connections.toml'.
 
 ---
 
@@ -122,7 +122,7 @@
     Condition
       Error in `snowflake_connection()`:
       ! An `account` parameter is required when '/CONFIG_DIR/connections.toml' is missing or empty.
-      i Pass `account` or define a [] section with an account field in '/CONFIG_DIR/connections.toml'.
+      i Pass `account` or define a [default] section with an account field in '/CONFIG_DIR/connections.toml'.
 
 # with incoming field values, connections.toml is not required
 
@@ -157,4 +157,13 @@
       role: "role"
       user: "user"
       authenticator: "snowflake"
+
+# error message is clear when named connection requested but file missing
+
+    Code
+      snowflake_connection("myconnection", .config_dir = config_dir)
+    Condition
+      Error in `snowflake_connection()`:
+      ! Named connection "myconnection" refers to a section in '/CONFIG_DIR/connections.toml', but that file does not exist.
+      i Create it and define a [myconnection] section, or omit the `name` parameter.
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -397,3 +397,13 @@ test_that("warning appears when both files define connections", {
     "testorg-from-connections"
   )
 })
+
+test_that("error message is clear when named connection requested but file missing", {
+  config_dir <- withr::local_tempdir()
+
+  expect_snapshot(
+    snowflake_connection("myconnection", .config_dir = config_dir),
+    error = TRUE,
+    transform = quoted_path_transformer
+  )
+})


### PR DESCRIPTION
Previously when a named connection was requested but the `connections.toml` file did not exist, the error message suggested defining a section in the non-existent file without acknowledging it was missing. This commit adds a more useful error message in this case.

Additionally, error messages for default connections now correctly refer to the `[default]` section instead of an empty `[]` section.

Fixes #23.