### PR TITLE
Improve error messages when connections.toml is missing a default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   existing have been removed (#25).
 * Error messages when a named connection is requested but the `connections.toml`
   file does not exist are now clearer (#23).
+* Error messages when `connections.toml` exists but lacks a needed connection are
+  now more specific and helpful (#26).
 
 # snowflakeauth 0.2.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -118,10 +118,31 @@ snowflake_connection <- function(
 
   # Validate that account is provided
   if (is_empty(params$account)) {
-    connection_name <- connection_name %||% "default"
+    # Give *highly specific* errors depending on how the user can resolve
+    # various cases.
+    if (!file.exists(connection_file) || length(connections) == 0) {
+      section_name <- connection_name %||% "default"
+      cli::cli_abort(c(
+        "An {.arg account} parameter is required when {.file {connection_file}}
+         is missing or empty.",
+        i = "Pass {.arg account} or define a {.field [{section_name}]}
+             section with an {.field account} field in {.file {connection_file}}."
+      ))
+    }
+    if (is.null(connection_name)) {
+      cli::cli_abort(c(
+        "No default connection defined in {.file {connection_file}}.",
+        i = "Define a {.field [default]} section in {.file {connection_file}},
+             pass another connection by {.arg name}, or pass connection
+             parameters to {.fn snowflake_connection} directly."
+      ))
+    }
     cli::cli_abort(c(
-      "An {.arg account} parameter is required when {.file {connection_file}} is missing or empty.",
-      i = "Pass {.arg account} or define a {.field [{connection_name}]} section with an {.field account} field in {.file {connection_file}}."
+      "The default connection name {.str {connection_name}} is not defined in
+       {.file {connection_file}}.",
+      i = "Define a {.field [{connection_name}]} section in
+           {.file {connection_file}}, pass another connection by {.arg name}, or
+           pass connection parameters to {.fn snowflake_connection} directly."
     ))
   }
 

--- a/tests/testthat/_snaps/config.md
+++ b/tests/testthat/_snaps/config.md
@@ -61,8 +61,8 @@
       snowflake_connection("test5", .config_dir = dir)
     Condition
       Error in `snowflake_connection()`:
-      ! An `account` parameter is required when './connections.toml' is missing or empty.
-      i Pass `account` or define a [test5] section with an account field in './connections.toml'.
+      ! The default connection name "test5" is not defined in './connections.toml'.
+      i Define a [test5] section in './connections.toml', pass another connection by `name`, or pass connection parameters to `snowflake_connection()` directly.
 
 ---
 
@@ -86,8 +86,8 @@
       snowflake_connection(.config_dir = dir)
     Condition
       Error in `snowflake_connection()`:
-      ! An `account` parameter is required when './connections.toml' is missing or empty.
-      i Pass `account` or define a [default] section with an account field in './connections.toml'.
+      ! No default connection defined in './connections.toml'.
+      i Define a [default] section in './connections.toml', pass another connection by `name`, or pass connection parameters to `snowflake_connection()` directly.
 
 ---
 


### PR DESCRIPTION
Previously when `connections.toml` existed but lacked the requested connection (or a "default" section), the error message erroneously claimed the file was "missing or empty".

This commit makes the error messages more specific: they now clearly state which connection is missing and provide helpful suggestions including the option to use a different connection by name.

Fixes #26.