### PR TITLE
Add support for the 'host' field in connections.toml files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # snowflakeauth (development version)
 
+* The `host` field in `connections.toml` files is now supported.
+
 # snowflakeauth 0.2.2
 
 * [On-disk connection caching][id_tokens] in the system keyring is now

--- a/R/config.R
+++ b/R/config.R
@@ -14,6 +14,9 @@
 #' Snowflake Connector for Python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#label-snowflake-connector-methods-connect):
 #'
 #' - `account`: A Snowflake account identifier.
+#' - `host`: An optional hostname for the Snowflake endpoint. When provided,
+#'    this is used instead of the default `{account}.snowflakecomputing.com`.
+#'    Useful for private endpoints or non-standard deployments.
 #' - `user`: A Snowflake username.
 #' - `role`: The role to use for the connection.
 #' - `schema`: The default schema to use for the connection.
@@ -595,6 +598,7 @@ parse_env_vars <- function() {
   # https://docs.snowflake.com/en/developer-guide/snowflake-cli/connecting/configure-connections#use-environment-variables-for-snowflake-credentials
   generic_envvars <- c(
     "SNOWFLAKE_ACCOUNT",
+    "SNOWFLAKE_HOST",
     "SNOWFLAKE_USER",
     "SNOWFLAKE_PASSWORD",
     "SNOWFLAKE_DATABASE",

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -31,7 +31,8 @@ snowflake_credentials <- function(
       params$account,
       params$token,
       params$token_file_path,
-      spcs_endpoint
+      spcs_endpoint,
+      host = params$host
     ),
     SNOWFLAKE_JWT = keypair_credentials(
       params$account,
@@ -41,7 +42,8 @@ snowflake_credentials <- function(
         params$private_key_path,
       params$private_key_file_pwd,
       spcs_endpoint,
-      role
+      role,
+      host = params$host
     ),
     WORKLOAD_IDENTITY = workload_identity_credentials(params),
     externalbrowser = externalbrowser_credentials(params),
@@ -118,12 +120,23 @@ has_expired <- function(expires_at, .now = Sys.time()) {
   is.null(expires_at) || (as.integer(.now) + 5L) > expires_at
 }
 
+snowflake_url <- function(host = NULL, account = NULL) {
+  if (!is.null(host) && nzchar(host)) {
+    sprintf("https://%s", host)
+  } else {
+    sprintf("https://%s.snowflakecomputing.com", account)
+  }
+}
+
 # Generic helper for calls to the /login-request endpoint.
-login_request <- function(account, data, user = NULL, extra_headers = list()) {
-  url <- sprintf(
-    "https://%s.snowflakecomputing.com/session/v1/login-request",
-    account
-  )
+login_request <- function(
+  account,
+  data,
+  user = NULL,
+  extra_headers = list(),
+  host = NULL
+) {
+  url <- sprintf("%s/session/v1/login-request", snowflake_url(host, account))
   base_params <- list(
     # Snowflake seems to whitelist what clients can request ID tokens, so
     # masquerade as the Python Connector for now.
@@ -190,11 +203,8 @@ login_request <- function(account, data, user = NULL, extra_headers = list()) {
 }
 
 # Renew an existing Snowflake session using its "master" token.
-renew_session <- function(account, session) {
-  url <- sprintf(
-    "https://%s.snowflakecomputing.com/session/token-request",
-    account
-  )
+renew_session <- function(account, session, host = NULL) {
+  url <- sprintf("%s/session/token-request", snowflake_url(host, account))
   body <- jsonlite::toJSON(
     list(
       oldSessionToken = session$token,

--- a/R/externalbrowser.R
+++ b/R/externalbrowser.R
@@ -5,6 +5,7 @@ externalbrowser_credentials <- function(
 ) {
   account <- params$account
   user <- params$user
+  host <- params$host
   if (!rlang::is_interactive()) {
     cli::cli_abort(c(
       "External browser authentication requires an interactive R session",
@@ -41,7 +42,7 @@ externalbrowser_credentials <- function(
     if (!has_expired(cached$master_expires_at)) {
       tryCatch(
         {
-          session <- renew_session(account, cached)
+          session <- renew_session(account, cached, host = host)
           session$id_token <- session$id_token %||% cached$id_token
           cache$set(session)
           # Update keyring if ID token changed
@@ -76,7 +77,8 @@ externalbrowser_credentials <- function(
             data = list(
               AUTHENTICATOR = "ID_TOKEN",
               TOKEN = cached$id_token
-            )
+            ),
+            host = host
           )
           cache$set(session)
           return(list(
@@ -104,7 +106,8 @@ externalbrowser_credentials <- function(
             data = list(
               AUTHENTICATOR = "ID_TOKEN",
               TOKEN = cached_token$token
-            )
+            ),
+            host = host
           )
           cache$set(session)
           # Note: we don't seem to get a new ID token with this flow (yet).
@@ -131,7 +134,7 @@ externalbrowser_credentials <- function(
 
   # Request the user's SSO URL and "proof key" from Snowflake.
   port <- httpuv::randomPort()
-  result <- request_sso_url(account, user, port)
+  result <- request_sso_url(account, user, port, host = host)
   sso_url <- result$sso_url
   proof_key <- result$proof_key
 
@@ -147,7 +150,8 @@ externalbrowser_credentials <- function(
       AUTHENTICATOR = "EXTERNALBROWSER",
       TOKEN = token,
       PROOF_KEY = proof_key
-    )
+    ),
+    host = host
   )
 
   # Cache the session for headless refreshing (when possible).
@@ -184,10 +188,10 @@ is_hosted_session <- function() {
     !grepl("localhost", Sys.getenv("RSTUDIO_HTTP_REFERER"), fixed = TRUE)
 }
 
-request_sso_url <- function(account, user, callback_port) {
+request_sso_url <- function(account, user, callback_port, host = NULL) {
   url <- sprintf(
-    "https://%s.snowflakecomputing.com/session/authenticator-request",
-    account
+    "%s/session/authenticator-request",
+    snowflake_url(host, account)
   )
   body <- jsonlite::toJSON(
     list(

--- a/R/keypair.R
+++ b/R/keypair.R
@@ -5,7 +5,8 @@ keypair_credentials <- function(
   private_key,
   private_key_pwd = NULL,
   spcs_endpoint = NULL,
-  role = "PUBLIC"
+  role = "PUBLIC",
+  host = NULL
 ) {
   jwt <- generate_jwt(account, user, private_key, private_key_pwd)
   # Important: the SPCS ingress handles key-pair authentication *differently*
@@ -24,7 +25,7 @@ keypair_credentials <- function(
   if (grepl("^https?://", spcs_endpoint)) {
     spcs_endpoint <- sub("^https?://", "", spcs_endpoint)
   }
-  account_url <- sprintf("https://%s.snowflakecomputing.com", account)
+  account_url <- snowflake_url(host, account)
   token <- exchange_jwt_for_token(account_url, jwt, spcs_endpoint, role)
   # Yes, this is actually the format of the Authorization header that SPCS
   # requires.

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -2,7 +2,8 @@ oauth_credentials <- function(
   account,
   token = NULL,
   token_file = NULL,
-  spcs_endpoint = NULL
+  spcs_endpoint = NULL,
+  host = NULL
 ) {
   if (!is.null(token_file)) {
     tryCatch(
@@ -25,7 +26,7 @@ oauth_credentials <- function(
     spcs_endpoint <- sub("^https?://", "", spcs_endpoint)
   }
 
-  account_url <- sprintf("https://%s.snowflakecomputing.com", account)
+  account_url <- snowflake_url(host, account)
   session_token <- exchange_oauth_token(account_url, token, spcs_endpoint)
 
   return(list(

--- a/R/workload_identity.R
+++ b/R/workload_identity.R
@@ -26,7 +26,7 @@ workload_identity_credentials <- function(
     # attempt to refresh the session.
     if (!has_expired(cached$master_expires_at)) {
       renewed <- tryCatch(
-        renew_session(account, cached),
+        renew_session(account, cached, host = params$host),
         error = function(e) NULL
       )
       if (!is.null(renewed)) {
@@ -66,7 +66,8 @@ workload_identity_credentials <- function(
       AUTHENTICATOR = "WORKLOAD_IDENTITY",
       PROVIDER = provider,
       TOKEN = token
-    )
+    ),
+    host = params$host
   )
 
   # Cache the session.

--- a/man/snowflake_connection.Rd
+++ b/man/snowflake_connection.Rd
@@ -39,6 +39,9 @@ The following is a list of common connection parameters. A more complete list
 can be found in the \href{https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#label-snowflake-connector-methods-connect}{documentation for the Snowflake Connector for Python}:
 \itemize{
 \item \code{account}: A Snowflake account identifier.
+\item \code{host}: An optional hostname for the Snowflake endpoint. When provided,
+this is used instead of the default \verb{\{account\}.snowflakecomputing.com}.
+Useful for private endpoints or non-standard deployments.
 \item \code{user}: A Snowflake username.
 \item \code{role}: The role to use for the connection.
 \item \code{schema}: The default schema to use for the connection.

--- a/tests/testthat/connections.toml
+++ b/tests/testthat/connections.toml
@@ -42,6 +42,13 @@ authenticator = "oauth"
 account = "testorg-test_account"
 private_key_file = "file"
 
+[test_with_host]
+account = "testorg-test_account"
+user = "user"
+token = "token"
+authenticator = "oauth"
+host = "myhost.example.com"
+
 [wif_valid]
 account = "testorg-test_account"
 user = "user"

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -439,3 +439,39 @@ test_that("WORKLOAD_IDENTITY authenticator requires workload_identity_provider",
     error = TRUE
   )
 })
+
+test_that("snowflake_url builds URLs correctly", {
+  expect_equal(
+    snowflake_url(account = "myaccount"),
+    "https://myaccount.snowflakecomputing.com"
+  )
+  expect_equal(
+    snowflake_url(host = "myhost.example.com", account = "myaccount"),
+    "https://myhost.example.com"
+  )
+  expect_equal(
+    snowflake_url(host = NULL, account = "myaccount"),
+    "https://myaccount.snowflakecomputing.com"
+  )
+  expect_equal(
+    snowflake_url(host = "", account = "myaccount"),
+    "https://myaccount.snowflakecomputing.com"
+  )
+})
+
+test_that("host field is read from connections.toml", {
+  dir <- test_path(".")
+  conn <- snowflake_connection("test_with_host", .config_dir = dir)
+  expect_equal(conn[["host"]], "myhost.example.com")
+})
+
+test_that("SNOWFLAKE_HOST environment variable is respected", {
+  withr::local_envvar(
+    c(
+      SNOWFLAKE_ACCOUNT = "env_account",
+      SNOWFLAKE_HOST = "myhost.example.com"
+    )
+  )
+  conn <- snowflake_connection(.config_dir = tempdir())
+  expect_equal(conn[["host"]], "myhost.example.com")
+})

--- a/tests/testthat/test-keypair.R
+++ b/tests/testthat/test-keypair.R
@@ -98,3 +98,22 @@ test_that("keypair_credentials works with encrypted private key", {
   expect_match(creds$Authorization, "^Bearer ")
   expect_equal(creds$`X-Snowflake-Authorization-Token-Type`, "KEYPAIR_JWT")
 })
+
+test_that("keypair_credentials uses host for SPCS exchange when provided", {
+  observed_url <- NULL
+  local_mocked_bindings(
+    exchange_jwt_for_token = function(account_url, jwt, spcs_endpoint, role) {
+      observed_url <<- account_url
+      list(access_token = "test_token")
+    }
+  )
+
+  keypair_credentials(
+    "testaccount",
+    "testuser",
+    test_path("unencrypted_rsa_key.p8"),
+    spcs_endpoint = "test.endpoint.com",
+    host = "myhost.example.com"
+  )
+  expect_equal(observed_url, "https://myhost.example.com")
+})

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -112,3 +112,38 @@ test_that("exchange_oauth_token handles missing token in response", {
     error = TRUE
   )
 })
+
+test_that("oauth_credentials uses host for SPCS exchange when provided", {
+  observed_url <- NULL
+  local_mocked_bindings(
+    exchange_oauth_token = function(account_url, token, spcs_endpoint) {
+      observed_url <<- account_url
+      list(token = "exchanged_token")
+    }
+  )
+
+  oauth_credentials(
+    "testaccount",
+    token = "test_token",
+    spcs_endpoint = "https://test.endpoint.com",
+    host = "myhost.example.com"
+  )
+  expect_equal(observed_url, "https://myhost.example.com")
+})
+
+test_that("oauth_credentials uses account-derived URL when host is not provided", {
+  observed_url <- NULL
+  local_mocked_bindings(
+    exchange_oauth_token = function(account_url, token, spcs_endpoint) {
+      observed_url <<- account_url
+      list(token = "exchanged_token")
+    }
+  )
+
+  oauth_credentials(
+    "testaccount",
+    token = "test_token",
+    spcs_endpoint = "https://test.endpoint.com"
+  )
+  expect_equal(observed_url, "https://testaccount.snowflakecomputing.com")
+})

--- a/tests/testthat/test-workload-identity.R
+++ b/tests/testthat/test-workload-identity.R
@@ -64,7 +64,7 @@ test_that("workload_identity_credentials renews session when expired but master 
   )
 
   local_mocked_bindings(
-    renew_session = function(account, session) {
+    renew_session = function(account, session, host = NULL) {
       list(
         token = "renewed_session_token",
         expires_at = as.numeric(Sys.time()) + 3600,
@@ -106,14 +106,15 @@ test_that("workload_identity_credentials falls back to fresh auth when renewal f
   )
 
   local_mocked_bindings(
-    renew_session = function(account, session) {
+    renew_session = function(account, session, host = NULL) {
       stop("Renewal failed")
     },
     login_request = function(
       account,
       data,
       user = NULL,
-      extra_headers = list()
+      extra_headers = list(),
+      host = NULL
     ) {
       list(
         token = "fresh_session_token",
@@ -150,7 +151,8 @@ test_that("workload_identity_credentials does fresh auth when no cache", {
       account,
       data,
       user = NULL,
-      extra_headers = list()
+      extra_headers = list(),
+      host = NULL
     ) {
       expect_equal(data$AUTHENTICATOR, "WORKLOAD_IDENTITY")
       expect_equal(data$PROVIDER, "OIDC")
@@ -194,7 +196,7 @@ test_that("workload_identity_credentials skips renewal when master token expired
   )
 
   local_mocked_bindings(
-    renew_session = function(account, session) {
+    renew_session = function(account, session, host = NULL) {
       renewal_called <<- TRUE
       stop("Should not be called")
     },
@@ -202,7 +204,8 @@ test_that("workload_identity_credentials skips renewal when master token expired
       account,
       data,
       user = NULL,
-      extra_headers = list()
+      extra_headers = list(),
+      host = NULL
     ) {
       list(
         token = "fresh_session_token",
@@ -243,7 +246,8 @@ test_that("workload_identity_credentials prefers token_file_path over inline tok
       account,
       data,
       user = NULL,
-      extra_headers = list()
+      extra_headers = list(),
+      host = NULL
     ) {
       expect_equal(data$TOKEN, "file_token")
       list(


### PR DESCRIPTION
This commit threads through the new `host` field supported by other Snowflake SDKs. When present it takes precendence over the `account` field when constructing the Snowflake URL.

In my understanding it's mainly used for private endpoints on SPCS or privatelink accounts.

Unit tests are included.