### PR TITLE
fix: has_expired reports true if token is expiring within 5m

### DIFF
--- a/R/credentials.R
+++ b/R/credentials.R
@@ -117,7 +117,7 @@ snowflake_session <- function(data, .now = Sys.time()) {
 
 # Check if a token timestamp will expire "in the next five minutes".
 has_expired <- function(expires_at, .now = Sys.time()) {
-  is.null(expires_at) || (as.integer(.now) + 5L) > expires_at
+  is.null(expires_at) || (as.integer(.now) + 300L) > expires_at
 }
 
 snowflake_url <- function(host = NULL, account = NULL) {

--- a/tests/testthat/test-credentials.R
+++ b/tests/testthat/test-credentials.R
@@ -1,0 +1,21 @@
+test_that("has_expired returns TRUE when token is already expired", {
+  now <- as.POSIXct("2024-01-01 12:00:00", tz = "UTC")
+  expires_at <- as.integer(now) - 1L
+  expect_true(has_expired(expires_at, .now = now))
+})
+
+test_that("has_expired returns TRUE when token expires within 5 minutes", {
+  now <- as.POSIXct("2024-01-01 12:00:00", tz = "UTC")
+  expires_at <- as.integer(now) + 299L
+  expect_true(has_expired(expires_at, .now = now))
+})
+
+test_that("has_expired returns FALSE when token expires after 5 minutes", {
+  now <- as.POSIXct("2024-01-01 12:00:00", tz = "UTC")
+  expires_at <- as.integer(now) + 301L
+  expect_false(has_expired(expires_at, .now = now))
+})
+
+test_that("has_expired returns TRUE when expires_at is NULL", {
+  expect_true(has_expired(NULL))
+})


### PR DESCRIPTION
The comment indicates that we should consider tokens expired within 5 minutes of their expires_at, but the code was checking for 5 seconds.