### PR TITLE
Add support for local Snowflake OAuth authentication

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # snowflakeauth (development version)
 
+* [Local Snowflake OAuth][local_oauth] authentication is now supported. Requires
+  the `httpuv` package (#41).
+
 * The `host` field in `connections.toml` files is now supported.
+
+[local_oauth]: https://docs.snowflake.com/en/user-guide/oauth-local-applications
 
 # snowflakeauth 0.2.2
 

--- a/R/config.R
+++ b/R/config.R
@@ -158,6 +158,9 @@ snowflake_connection <- function(
   ) {
     params$authenticator <- "SNOWFLAKE_JWT"
   }
+  if (tolower(params$authenticator) == "oauth_authorization_code") {
+    params$authenticator <- "oauth_authorization_code"
+  }
 
   # Validate OAuth configuration
   if (

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -47,9 +47,11 @@ snowflake_credentials <- function(
     ),
     WORKLOAD_IDENTITY = workload_identity_credentials(params),
     externalbrowser = externalbrowser_credentials(params),
+    oauth_authorization_code = oauth_authorization_code_credentials(params),
     cli::cli_abort(c(
       "Unsupported authenticator: {.str {params$authenticator}}.",
-      "i" = "Supported authenticators: oauth, SNOWFLAKE_JWT, externalbrowser"
+      "i" = "Supported authenticators: oauth, SNOWFLAKE_JWT, externalbrowser,
+             oauth_authorization_code"
     ))
   )
 }

--- a/R/oauth_authorization_code.R
+++ b/R/oauth_authorization_code.R
@@ -1,0 +1,381 @@
+oauth_authorization_code_credentials <- function(
+  params,
+  cache = session_cache(params)
+) {
+  account <- params$account
+  user <- params$user
+  host <- params$host
+
+  # Check for a cached session before launching the browser flow.
+  cached <- cache$get()
+  if (!is.null(cached)) {
+    if (!has_expired(cached$expires_at)) {
+      return(
+        list(
+          Authorization = sprintf('Snowflake Token="%s"', cached$token)
+        )
+      )
+    }
+
+    if (!has_expired(cached$master_expires_at)) {
+      tryCatch(
+        {
+          session <- renew_session(account, cached, host = host)
+          cache$set(session)
+          return(
+            list(
+              Authorization = sprintf('Snowflake Token="%s"', session$token)
+            )
+          )
+        },
+        error = function(e) {
+          NULL
+        }
+      )
+    }
+  }
+
+  base_url <- snowflake_url(host, account)
+  client_id <- "LOCAL_APPLICATION"
+  client_secret <- "LOCAL_APPLICATION"
+  token_url <- params$oauth_token_request_url %||%
+    paste0(base_url, "/oauth/token-request")
+  scope <- build_scope(params$oauth_scope, params$role)
+
+  # Try refresh token from keyring.
+  keyring_user <- user %||% account
+  if (use_keyring()) {
+    cached_refresh <- keyring_get_token(
+      account,
+      keyring_user,
+      "OAUTH_REFRESH_TOKEN"
+    )
+    if (!is.null(cached_refresh)) {
+      tryCatch(
+        {
+          tokens <- request_oauth_tokens(
+            token_url,
+            grant_type = "refresh_token",
+            client_id = client_id,
+            client_secret = client_secret,
+            refresh_token = cached_refresh$token,
+            scope = scope
+          )
+          session <- login_request(
+            account,
+            user = user,
+            data = list(AUTHENTICATOR = "OAUTH", TOKEN = tokens$access_token),
+            host = host
+          )
+          cache$set(session)
+          # Update refresh token if a new one was issued.
+          if (!is.null(tokens$refresh_token)) {
+            keyring_cache_token(
+              account,
+              keyring_user,
+              "OAUTH_REFRESH_TOKEN",
+              tokens$refresh_token,
+              as.numeric(Sys.time()) + (90 * 24 * 60 * 60)
+            )
+          }
+          return(
+            list(
+              Authorization = sprintf('Snowflake Token="%s"', session$token)
+            )
+          )
+        },
+        error = function(e) {
+          keyring_clear_token(account, keyring_user, "OAUTH_REFRESH_TOKEN")
+          NULL
+        }
+      )
+    }
+  }
+
+  # Full browser flow — requires interactive session and httpuv.
+  if (!rlang::is_interactive()) {
+    cli::cli_abort(
+      c(
+        "local OAuth authentication requires an interactive R session",
+        "i" = "Use a different authenticator"
+      )
+    )
+  }
+
+  if (is_hosted_session()) {
+    cli::cli_abort(
+      c(
+        "local OAuth authentication does not work in a hosted environment",
+        "i" = "Use a different authenticator"
+      )
+    )
+  }
+
+  rlang::check_installed(
+    "httpuv",
+    reason = "for local OAuth authentication"
+  )
+  authorization_url <- params$oauth_authorization_url %||%
+    paste0(base_url, "/oauth/authorize")
+
+  pkce <- generate_pkce()
+  state <- base64url_encode(openssl::rand_bytes(32))
+  port <- httpuv::randomPort()
+  redirect_uri <- sprintf("http://127.0.0.1:%d", port)
+
+  auth_url <- build_authorization_url(
+    authorization_url,
+    client_id = client_id,
+    redirect_uri = redirect_uri,
+    code_challenge = pkce$challenge,
+    state = state,
+    scope = scope
+  )
+
+  utils::browseURL(auth_url)
+  result <- oauth_code_listen(port)
+
+  if (!identical(result$state, state)) {
+    cli::cli_abort("OAuth state mismatch (possible CSRF attack)")
+  }
+
+  tokens <- request_oauth_tokens(
+    token_url,
+    grant_type = "authorization_code",
+    client_id = client_id,
+    client_secret = client_secret,
+    code = result$code,
+    redirect_uri = redirect_uri,
+    code_verifier = pkce$verifier
+  )
+
+  session <- login_request(
+    account,
+    user = user,
+    data = list(AUTHENTICATOR = "OAUTH", TOKEN = tokens$access_token),
+    host = host
+  )
+  cache$set(session)
+
+  # Cache refresh token for cross-session persistence.
+  if (!is.null(tokens$refresh_token) && use_keyring()) {
+    keyring_cache_token(
+      account,
+      keyring_user,
+      "OAUTH_REFRESH_TOKEN",
+      tokens$refresh_token,
+      as.numeric(Sys.time()) + (90 * 24 * 60 * 60)
+    )
+  }
+
+  list(Authorization = sprintf('Snowflake Token="%s"', session$token))
+}
+
+generate_pkce <- function() {
+  verifier <- base64url_encode(openssl::rand_bytes(32))
+  challenge <- base64url_encode(openssl::sha256(charToRaw(verifier)))
+  list(verifier = verifier, challenge = challenge)
+}
+
+base64url_encode <- function(raw_bytes) {
+  encoded <- openssl::base64_encode(raw_bytes)
+  encoded <- gsub("+", "-", encoded, fixed = TRUE)
+  encoded <- gsub("/", "_", encoded, fixed = TRUE)
+  gsub("=", "", encoded, fixed = TRUE)
+}
+
+build_scope <- function(oauth_scope = NULL, role = NULL) {
+  scope <- oauth_scope %||% ""
+  if (!nzchar(scope) && !is.null(role)) {
+    scope <- paste0("session:role:", role)
+  }
+  tokens <- if (nzchar(scope)) strsplit(trimws(scope), "\\s+")[[1]] else
+    character()
+  if (!("refresh_token" %in% tokens)) {
+    tokens <- c(tokens, "refresh_token")
+  }
+  paste(tokens, collapse = " ")
+}
+
+build_authorization_url <- function(
+  base_url,
+  client_id,
+  redirect_uri,
+  code_challenge,
+  state,
+  scope = ""
+) {
+  params <- list(
+    client_id = client_id,
+    response_type = "code",
+    redirect_uri = redirect_uri,
+    code_challenge = code_challenge,
+    code_challenge_method = "S256",
+    state = state
+  )
+  if (nzchar(scope)) {
+    params$scope <- scope
+  }
+  query <- paste0(
+    curl::curl_escape(names(params)),
+    "=",
+    curl::curl_escape(params),
+    collapse = "&"
+  )
+  paste0(base_url, "?", query)
+}
+
+request_oauth_tokens <- function(
+  token_url,
+  grant_type,
+  client_id,
+  client_secret,
+  code = NULL,
+  redirect_uri = NULL,
+  code_verifier = NULL,
+  refresh_token = NULL,
+  scope = NULL
+) {
+  form_data <- list(grant_type = grant_type)
+  if (!is.null(code)) form_data$code <- code
+  if (!is.null(redirect_uri)) form_data$redirect_uri <- redirect_uri
+  if (!is.null(code_verifier)) form_data$code_verifier <- code_verifier
+  if (!is.null(refresh_token)) form_data$refresh_token <- refresh_token
+  if (!is.null(scope)) form_data$scope <- scope
+
+  body <- formEncode(form_data)
+  credentials <- openssl::base64_encode(
+    charToRaw(paste0(client_id, ":", client_secret))
+  )
+
+  handle <- curl::new_handle()
+  curl::handle_setopt(handle, postfields = body)
+  curl::handle_setheaders(
+    handle,
+    `Content-Type` = "application/x-www-form-urlencoded",
+    `Accept` = "application/json",
+    `Authorization` = paste("Basic", credentials)
+  )
+
+  resp <- curl::curl_fetch_memory(token_url, handle)
+  if (resp$status_code >= 400) {
+    detail <- NULL
+    tryCatch(
+      {
+        content <- jsonlite::fromJSON(
+          rawToChar(resp$content),
+          simplifyVector = FALSE
+        )
+        detail <- content$message %||%
+          content$error_description %||%
+          content$error
+      },
+      error = function(e) NULL
+    )
+    cli::cli_abort(
+      c(
+        "OAuth token request failed with status {resp$status_code}",
+        i = detail
+      )
+    )
+  }
+
+  content <- jsonlite::fromJSON(rawToChar(resp$content), simplifyVector = FALSE)
+  if (is.null(content$access_token)) {
+    cli::cli_abort("OAuth token response missing access_token")
+  }
+
+  list(
+    access_token = content$access_token,
+    refresh_token = content$refresh_token,
+    expires_in = content$expires_in
+  )
+}
+
+oauth_code_listen <- function(port) {
+  code <- NULL
+  state <- NULL
+  done <- FALSE
+
+  listen <- function(req) {
+    if (!identical(req$PATH_INFO, "/") || req$REQUEST_METHOD != "GET") {
+      return(
+        list(
+          status = 404L,
+          headers = list("Content-Type" = "text/plain"),
+          body = "Not found"
+        )
+      )
+    }
+
+    query <- req$QUERY_STRING
+    if (!is.character(query) || !nzchar(query)) {
+      done <<- TRUE
+      return(
+        list(
+          status = 400L,
+          headers = list("Content-Type" = "text/plain"),
+          body = "Missing query parameters"
+        )
+      )
+    }
+
+    parsed <- parse_query_string(query)
+    if (!is.null(parsed$error)) {
+      done <<- TRUE
+      return(
+        list(
+          status = 400L,
+          headers = list("Content-Type" = "text/plain"),
+          body = paste(
+            "Authorization error:",
+            parsed$error_description %||% parsed$error
+          )
+        )
+      )
+    }
+
+    code <<- parsed$code
+    state <<- parsed$state
+    done <<- TRUE
+
+    list(
+      status = 200L,
+      headers = list("Content-Type" = "text/plain"),
+      body = "Authentication complete. Please close this page and return to R."
+    )
+  }
+
+  server <- httpuv::startServer("127.0.0.1", port, list(call = listen))
+  on.exit(httpuv::stopServer(server), add = TRUE)
+
+  rlang::inform("Waiting for authentication in browser...")
+  rlang::inform("Press Esc/Ctrl + C to abort")
+  while (!done) {
+    httpuv::service()
+  }
+  httpuv::service()
+
+  if (is.null(code)) {
+    cli::cli_abort(
+      "local OAuth authentication failed: no authorization code received"
+    )
+  }
+
+  list(code = code, state = state)
+}
+
+parse_query_string <- function(query) {
+  query <- sub("^\\?", "", query)
+  pairs <- strsplit(query, "&", fixed = TRUE)[[1]]
+  result <- list()
+  for (pair in pairs) {
+    eq_pos <- regexpr("=", pair, fixed = TRUE)
+    if (eq_pos > 0) {
+      key <- substr(pair, 1, eq_pos - 1)
+      value <- substr(pair, eq_pos + 1, nchar(pair))
+      result[[curl::curl_unescape(key)]] <- curl::curl_unescape(value)
+    }
+  }
+  result
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,12 +93,13 @@ The following table details authentication methods supported by `snowflake_crede
 | Method | Supported | Notes |
 |----|:-:|:------|
 | Browser-based SSO | ✅ | Interactive, desktop-only |
+| Local Snowflake OAuth | ✅ | Interactive, desktop-only |
 | Key-pair | ✅ | |
 | OAuth token | ✅ | |
 | Workload identity federation | ✅ | OIDC only |
 | Programmatic access token (PAT) | ❌ | |
 | OAuth 2.0 client credentials | ❌ | Rarely used, not planned |
-| OAuth 2.0 authorization code | ❌ | Rarely used, not planned |
+| OAuth 2.0 authorization code | ❌ | For external IdPs, not planned |
 | Username and password | ❌ | Insecure, not planned |
 | Username and password with MFA | ❌ | Not planned |
 | Native SSO (Okta-only) | ❌ | Superceded by other methods, not planned |

--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
+---
+output: github_document
+---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+
+
 
 # snowflakeauth
 
 <!-- badges: start -->
-
 [![lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![R-CMD-check](https://github.com/posit-dev/snowflakeauth/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/posit-dev/snowflakeauth/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-`snowflakeauth` is a toolkit for authenticating with Snowflake. It aims
-for compatibility with the `connections.toml` and `config.toml` files
-used by the [Snowflake Connector for
-Python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect)
+`snowflakeauth` is a toolkit for authenticating with Snowflake. It aims for
+compatibility with the `connections.toml` and `config.toml` files used by the
+[Snowflake Connector for Python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect)
 and the [Snowflake
 CLI](https://docs.snowflake.com/en/developer-guide/snowflake-cli/connecting/configure-connections),
-so that R users can use a consistent approach to Snowflake credentials
-across both languages.
+so that R users can use a consistent approach to Snowflake credentials across
+both languages.
 
-`snowflakeauth` is intended for use by R package authors targeting the
-Snowflake platform.
+`snowflakeauth` is intended for use by R package authors
+targeting the Snowflake platform.
 
 ## Installation
 
@@ -39,10 +42,11 @@ pak::pak("posit-dev/snowflakeauth")
 
 ## Example
 
-`snowflakeauth` can pick up on the default Snowflake connection
-parameters from the `connections.toml` and `config.toml` files used by
-the Python Connector for Snowflake and the Snowflake CLI (or any other
-named connection, for that matter):
+`snowflakeauth` can pick up on the default Snowflake connection parameters from
+the `connections.toml` and `config.toml` files used by the Python Connector for
+Snowflake and the Snowflake CLI (or any other named connection, for that
+matter):
+
 
 ``` r
 library(snowflakeauth)
@@ -54,6 +58,7 @@ snowflake_connection(name = "testing")
 
 or you can define the parameters of a connection manually:
 
+
 ``` r
 snowflake_connection(
   account = "myaccount",
@@ -63,8 +68,9 @@ snowflake_connection(
 )
 ```
 
-These parameters can then be used to retrieve credentials, which take
-the form of a one or more of HTTP headers:
+These parameters can then be used to retrieve credentials, which take the form
+of a one or more of HTTP headers:
+
 
 ``` r
 conn <- snowflake_connection(
@@ -78,26 +84,26 @@ snowflake_credentials(conn)
 
 ## Supported Authentication Methods
 
-The following table details authentication methods supported by
-`snowflake_credentials()`:
+The following table details authentication methods supported by `snowflake_credentials()`:
 
 | Method | Supported | Notes |
-|----|:--:|:---|
+|----|:-:|:------|
 | Browser-based SSO | ✅ | Interactive, desktop-only |
-| Key-pair | ✅ |  |
-| OAuth token | ✅ |  |
+| Local Snowflake OAuth | ✅ | Interactive, desktop-only |
+| Key-pair | ✅ | |
+| OAuth token | ✅ | |
 | Workload identity federation | ✅ | OIDC only |
-| Programmatic access token (PAT) | ❌ |  |
+| Programmatic access token (PAT) | ❌ | |
 | OAuth 2.0 client credentials | ❌ | Rarely used, not planned |
-| OAuth 2.0 authorization code | ❌ | Rarely used, not planned |
+| OAuth 2.0 authorization code | ❌ | For external IdPs, not planned |
 | Username and password | ❌ | Insecure, not planned |
 | Username and password with MFA | ❌ | Not planned |
 | Native SSO (Okta-only) | ❌ | Superceded by other methods, not planned |
 
 ## Limitations
 
-- Browser-based authentication is known to fail in Positron, but should
-  work in RStudio.
+- Browser-based authentication is known to fail in Positron, but should work in
+  RStudio.
 
 ## License
 

--- a/tests/testthat/connections.toml
+++ b/tests/testthat/connections.toml
@@ -74,3 +74,16 @@ account = "testorg-test_account"
 user = "user"
 authenticator = "WORKLOAD_IDENTITY"
 token = "test_token"
+
+[oauth_auth_code]
+account = "testaccount"
+authenticator = "oauth_authorization_code"
+
+[oauth_auth_code_with_role]
+account = "testaccount"
+authenticator = "oauth_authorization_code"
+role = "ANALYST"
+
+[oauth_auth_code_uppercase]
+account = "testaccount"
+authenticator = "OAUTH_AUTHORIZATION_CODE"

--- a/tests/testthat/test-oauth-authorization-code.R
+++ b/tests/testthat/test-oauth-authorization-code.R
@@ -1,0 +1,646 @@
+test_that("oauth_authorization_code_credentials returns cached session when valid", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL
+  )
+
+  mock_session <- list(
+    token = "cached_session_token",
+    expires_at = as.numeric(Sys.time()) + 3600,
+    master_token = "cached_master_token",
+    master_expires_at = as.numeric(Sys.time()) + 7200
+  )
+
+  mock_cache <- list(
+    get = function() mock_session,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="cached_session_token"')
+  )
+})
+
+test_that("cached session works in non-interactive sessions", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL
+  )
+
+  mock_session <- list(
+    token = "cached_session_token",
+    expires_at = as.numeric(Sys.time()) + 3600,
+    master_token = "cached_master_token",
+    master_expires_at = as.numeric(Sys.time()) + 7200
+  )
+
+  mock_cache <- list(
+    get = function() mock_session,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="cached_session_token"')
+  )
+})
+
+test_that("oauth_authorization_code_credentials renews session when expired but master valid", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL
+  )
+
+  mock_session <- list(
+    token = "expired_session_token",
+    expires_at = as.numeric(Sys.time()) - 100,
+    master_token = "valid_master_token",
+    master_expires_at = as.numeric(Sys.time()) + 3600
+  )
+
+  cached_session <- NULL
+  mock_cache <- list(
+    get = function() mock_session,
+    set = function(session) cached_session <<- session,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    renew_session = function(account, session, host = NULL) {
+      list(
+        token = "renewed_session_token",
+        expires_at = as.numeric(Sys.time()) + 3600,
+        master_token = session$master_token,
+        master_expires_at = session$master_expires_at
+      )
+    }
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="renewed_session_token"')
+  )
+  expect_equal(cached_session$token, "renewed_session_token")
+})
+
+test_that("oauth_authorization_code_credentials uses refresh token from keyring", {
+  params <- list(
+    account = "testaccount",
+    user = "testuser",
+    host = NULL,
+    oauth_client_id = NULL,
+    oauth_client_secret = NULL,
+    oauth_token_request_url = NULL,
+    oauth_scope = NULL,
+    role = NULL
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    use_keyring = function() TRUE,
+    keyring_get_token = function(account, user, token_type) {
+      if (token_type == "OAUTH_REFRESH_TOKEN") {
+        list(token = "cached_refresh_token", expires_at = Inf)
+      } else {
+        NULL
+      }
+    },
+    keyring_cache_token = function(
+      account,
+      user,
+      token_type,
+      token,
+      expires_at
+    ) {
+      NULL
+    },
+    request_oauth_tokens = function(token_url, grant_type, ...) {
+      expect_equal(grant_type, "refresh_token")
+      list(
+        access_token = "new_access_token",
+        refresh_token = "new_refresh_token",
+        expires_in = 600
+      )
+    },
+    login_request = function(
+      account,
+      data,
+      user = NULL,
+      extra_headers = list(),
+      host = NULL
+    ) {
+      expect_equal(data$AUTHENTICATOR, "OAUTH")
+      expect_equal(data$TOKEN, "new_access_token")
+      list(
+        token = "session_from_refresh",
+        expires_at = as.numeric(Sys.time()) + 3600
+      )
+    }
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="session_from_refresh"')
+  )
+})
+
+test_that("oauth_authorization_code_credentials clears keyring on refresh failure", {
+  params <- list(
+    account = "testaccount",
+    user = "testuser",
+    host = NULL,
+    oauth_client_id = NULL,
+    oauth_client_secret = NULL,
+    oauth_authorization_url = NULL,
+    oauth_token_request_url = NULL,
+    oauth_scope = NULL,
+    role = NULL
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  keyring_cleared <- FALSE
+  browser_opened <- FALSE
+
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    browseURL = function(url) NULL,
+    .package = "utils"
+  )
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    use_keyring = function() TRUE,
+    keyring_get_token = function(account, user, token_type) {
+      if (token_type == "OAUTH_REFRESH_TOKEN") {
+        list(token = "expired_refresh_token", expires_at = Inf)
+      } else {
+        NULL
+      }
+    },
+    keyring_clear_token = function(account, user, token_type) {
+      keyring_cleared <<- TRUE
+    },
+    keyring_cache_token = function(
+      account,
+      user,
+      token_type,
+      token,
+      expires_at
+    ) {
+      NULL
+    },
+    request_oauth_tokens = function(token_url, grant_type, ...) {
+      if (grant_type == "refresh_token") {
+        stop("refresh token expired")
+      }
+      list(
+        access_token = "fresh_access_token",
+        refresh_token = NULL,
+        expires_in = 600
+      )
+    },
+    login_request = function(
+      account,
+      data,
+      user = NULL,
+      extra_headers = list(),
+      host = NULL
+    ) {
+      list(
+        token = "session_from_browser",
+        expires_at = as.numeric(Sys.time()) + 3600
+      )
+    },
+    oauth_code_listen = function(port) {
+      browser_opened <<- TRUE
+      list(code = "auth_code", state = "test_state")
+    },
+    generate_pkce = function() {
+      list(verifier = "test_verifier", challenge = "test_challenge")
+    },
+    base64url_encode = function(raw_bytes) "test_state"
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_true(keyring_cleared)
+  expect_true(browser_opened)
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="session_from_browser"')
+  )
+})
+
+test_that("oauth_authorization_code_credentials does full browser flow", {
+  params <- list(
+    account = "testaccount",
+    user = "testuser",
+    host = NULL,
+    oauth_client_id = NULL,
+    oauth_client_secret = NULL,
+    oauth_authorization_url = NULL,
+    oauth_token_request_url = NULL,
+    oauth_scope = NULL,
+    role = NULL
+  )
+
+  cached_session <- NULL
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) cached_session <<- session,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    browseURL = function(url) NULL,
+    .package = "utils"
+  )
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    use_keyring = function() FALSE,
+    generate_pkce = function() {
+      list(verifier = "test_verifier", challenge = "test_challenge")
+    },
+    base64url_encode = function(raw_bytes) "test_state",
+    oauth_code_listen = function(port) {
+      list(code = "auth_code_123", state = "test_state")
+    },
+    request_oauth_tokens = function(
+      token_url,
+      grant_type,
+      client_id,
+      client_secret,
+      ...
+    ) {
+      expect_equal(grant_type, "authorization_code")
+      expect_equal(client_id, "LOCAL_APPLICATION")
+      expect_equal(client_secret, "LOCAL_APPLICATION")
+      args <- list(...)
+      expect_equal(args$code, "auth_code_123")
+      expect_equal(args$code_verifier, "test_verifier")
+      list(
+        access_token = "browser_access_token",
+        refresh_token = NULL,
+        expires_in = 600
+      )
+    },
+    login_request = function(
+      account,
+      data,
+      user = NULL,
+      extra_headers = list(),
+      host = NULL
+    ) {
+      expect_equal(data$AUTHENTICATOR, "OAUTH")
+      expect_equal(data$TOKEN, "browser_access_token")
+      list(
+        token = "session_token",
+        expires_at = as.numeric(Sys.time()) + 3600
+      )
+    }
+  )
+
+  result <- oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_equal(
+    result,
+    list(Authorization = 'Snowflake Token="session_token"')
+  )
+  expect_equal(cached_session$token, "session_token")
+})
+
+test_that("oauth_authorization_code_credentials aborts on state mismatch", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL,
+    oauth_client_id = NULL,
+    oauth_client_secret = NULL,
+    oauth_authorization_url = NULL,
+    oauth_token_request_url = NULL,
+    oauth_scope = NULL,
+    role = NULL
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    browseURL = function(url) NULL,
+    .package = "utils"
+  )
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    use_keyring = function() FALSE,
+    generate_pkce = function() {
+      list(verifier = "test_verifier", challenge = "test_challenge")
+    },
+    base64url_encode = function(raw_bytes) "expected_state",
+    oauth_code_listen = function(port) {
+      list(code = "auth_code", state = "wrong_state")
+    }
+  )
+
+  expect_error(
+    oauth_authorization_code_credentials(params, cache = mock_cache),
+    "state mismatch"
+  )
+})
+
+test_that("oauth_authorization_code_credentials aborts in non-interactive session", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL,
+    oauth_scope = NULL,
+    oauth_token_request_url = NULL,
+    role = NULL
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    use_keyring = function() FALSE
+  )
+
+  expect_error(
+    oauth_authorization_code_credentials(params, cache = mock_cache),
+    "interactive"
+  )
+})
+
+test_that("oauth_authorization_code_credentials aborts in hosted session", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL,
+    oauth_scope = NULL,
+    oauth_token_request_url = NULL,
+    role = NULL
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    use_keyring = function() FALSE,
+    is_hosted_session = function() TRUE
+  )
+
+  expect_error(
+    oauth_authorization_code_credentials(params, cache = mock_cache),
+    "hosted"
+  )
+})
+
+test_that("generate_pkce produces valid verifier and challenge", {
+  pkce <- generate_pkce()
+
+  expect_type(pkce$verifier, "character")
+  expect_type(pkce$challenge, "character")
+
+  # Verifier should be base64url-encoded (no +, /, or =)
+  expect_false(grepl("[+/=]", pkce$verifier))
+  # Challenge should be base64url-encoded
+  expect_false(grepl("[+/=]", pkce$challenge))
+
+  # Challenge should be SHA-256 of verifier, base64url-encoded
+  expected_challenge <- base64url_encode(
+    openssl::sha256(charToRaw(pkce$verifier))
+  )
+  expect_equal(pkce$challenge, expected_challenge)
+})
+
+test_that("base64url_encode removes padding and replaces characters", {
+  # Known input that produces +, /, and = in standard base64
+  raw_input <- as.raw(c(0xfb, 0xff, 0xfe))
+  result <- base64url_encode(raw_input)
+
+  expect_false(grepl("+", result, fixed = TRUE))
+  expect_false(grepl("/", result, fixed = TRUE))
+  expect_false(grepl("=", result, fixed = TRUE))
+})
+
+test_that("build_authorization_url includes all required params", {
+  url <- build_authorization_url(
+    "https://account.snowflakecomputing.com/oauth/authorize",
+    client_id = "LOCAL_APPLICATION",
+    redirect_uri = "http://127.0.0.1:8080",
+    code_challenge = "challenge123",
+    state = "state456",
+    scope = "session:role:ANALYST"
+  )
+
+  expect_match(
+    url,
+    "^https://account.snowflakecomputing.com/oauth/authorize\\?"
+  )
+  expect_match(url, "client_id=LOCAL_APPLICATION")
+  expect_match(url, "response_type=code")
+  expect_match(url, "redirect_uri=http")
+  expect_match(url, "code_challenge=challenge123")
+  expect_match(url, "code_challenge_method=S256")
+  expect_match(url, "state=state456")
+  expect_match(url, "scope=session")
+})
+
+test_that("build_authorization_url omits scope when empty", {
+  url <- build_authorization_url(
+    "https://account.snowflakecomputing.com/oauth/authorize",
+    client_id = "LOCAL_APPLICATION",
+    redirect_uri = "http://127.0.0.1:8080",
+    code_challenge = "challenge123",
+    state = "state456",
+    scope = ""
+  )
+
+  expect_no_match(url, "scope=")
+})
+
+test_that("scope auto-populates with role when scope is empty", {
+  params <- list(
+    account = "testaccount",
+    user = NULL,
+    host = NULL,
+    oauth_client_id = NULL,
+    oauth_client_secret = NULL,
+    oauth_authorization_url = NULL,
+    oauth_token_request_url = NULL,
+    oauth_scope = NULL,
+    role = "ANALYST"
+  )
+
+  mock_cache <- list(
+    get = function() NULL,
+    set = function(session) NULL,
+    clear = function() NULL
+  )
+
+  captured_url <- NULL
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  local_mocked_bindings(
+    browseURL = function(url) captured_url <<- url,
+    .package = "utils"
+  )
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    use_keyring = function() FALSE,
+    generate_pkce = function() {
+      list(verifier = "v", challenge = "c")
+    },
+    base64url_encode = function(raw_bytes) "state",
+    oauth_code_listen = function(port) {
+      list(code = "code", state = "state")
+    },
+    request_oauth_tokens = function(token_url, grant_type, ...) {
+      args <- list(...)
+      list(access_token = "tok", refresh_token = NULL, expires_in = 600)
+    },
+    login_request = function(
+      account,
+      data,
+      user = NULL,
+      extra_headers = list(),
+      host = NULL
+    ) {
+      list(token = "session", expires_at = as.numeric(Sys.time()) + 3600)
+    }
+  )
+
+  oauth_authorization_code_credentials(params, cache = mock_cache)
+
+  expect_match(captured_url, "session%3Arole%3AANALYST")
+})
+
+test_that("parse_query_string correctly parses query parameters", {
+  result <- parse_query_string("?code=abc123&state=xyz789")
+  expect_equal(result$code, "abc123")
+  expect_equal(result$state, "xyz789")
+
+  result2 <- parse_query_string("code=hello%20world&other=value")
+  expect_equal(result2$code, "hello world")
+  expect_equal(result2$other, "value")
+})
+
+test_that("parse_query_string handles = in values", {
+  result <- parse_query_string("code=abc%3Ddef&state=xyz")
+  expect_equal(result$code, "abc=def")
+  expect_equal(result$state, "xyz")
+
+  result2 <- parse_query_string("code=a=b=c&state=ok")
+  expect_equal(result2$code, "a=b=c")
+  expect_equal(result2$state, "ok")
+})
+
+test_that("build_scope includes refresh_token by default", {
+  expect_equal(build_scope(), "refresh_token")
+  expect_equal(
+    build_scope(role = "ANALYST"),
+    "session:role:ANALYST refresh_token"
+  )
+  expect_equal(
+    build_scope(oauth_scope = "session:role:ADMIN"),
+    "session:role:ADMIN refresh_token"
+  )
+})
+
+test_that("build_scope does not duplicate refresh_token", {
+  expect_equal(
+    build_scope(oauth_scope = "refresh_token"),
+    "refresh_token"
+  )
+  expect_equal(
+    build_scope(oauth_scope = "session:role:ADMIN refresh_token"),
+    "session:role:ADMIN refresh_token"
+  )
+})
+
+test_that("build_scope uses exact token matching for refresh_token", {
+  result <- build_scope(oauth_scope = "session:role:team_refresh_token_ops")
+  expect_equal(
+    result,
+    "session:role:team_refresh_token_ops refresh_token"
+  )
+})
+
+test_that("config normalizes OAUTH_AUTHORIZATION_CODE to lowercase", {
+  conn <- snowflake_connection(
+    name = "oauth_auth_code_uppercase",
+    .config_dir = test_path()
+  )
+  expect_equal(conn$authenticator, "oauth_authorization_code")
+})
+
+test_that("config accepts oauth_authorization_code without user", {
+  conn <- snowflake_connection(
+    name = "oauth_auth_code",
+    .config_dir = test_path()
+  )
+  expect_equal(conn$authenticator, "oauth_authorization_code")
+  expect_null(conn$user)
+})


### PR DESCRIPTION
This commit implements [the new `OAUTH_AUTHORIZATION_CODE` authenticator][0], which is a standard OAuth authorization code flow with PKCE targeting desktop applications.

It serves as a drop-in replacement for `externalbrowser` auth, and has the benefit of working even without SSO. Plus it's easier to configure.

Under the hood it uses Snowflake's built-in `LOCAL_APPLICATION` integration, which requires no custom security integration setup.

Finally, it's also hooked into the existing keyring subsystem, and given that refresh tokens last 90 days by default, this is likely to mean *dramatically* fewer browser logins than the existing browser flow (which requires it every four hours).

Closes #41.

[0]: https://docs.snowflake.com/en/user-guide/oauth-local-applications